### PR TITLE
Direct feather export from pf-classify.r

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -5,10 +5,11 @@ params {
     config_profile_description = 'Minimal test dataset to check pipeline function'
     params.inputgenomes = "testdata/genomes/"
     params.hmms    = "testdata/profiles/"
+    params.hmm_mincov = 0.7
     params.profiles_hierarchy = "testdata/profiles/hmm_profile_hierarchy.tsv"
     params.dbsource = "GTDB:GTDB:04-RS89"
     params.gtdb_arc_metadata = "testdata/arc_metadata.tsv"
     params.gtdb_bac_metadata = "testdata/bac_metadata.tsv"
-    params.hmm_mincov = "0.9"
     params.outputdir = "test_results/"
+    params.featherprefix = 'test-file'
 }

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ channels:
   - matricaria
 dependencies:
   - hmmer=3.3
-  - pfitmap-db>=1.9.3.2
+  - pfitmap-db>=1.9.7
   - r-stringi

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,3 +1,9 @@
+executor {
+  $local {
+    memory = '120 GB'
+  }
+}
+
 // profiles configuration
 profiles {
 /* 


### PR DESCRIPTION
I deleted the export process and modified the `pf-classify.r` call so it writes feather files directly. I also did some cleaning up plus docs.

Let's save this in `dev` for the moment because I think I'll do more changes in `pfitmap-db` that will cause a bump of version number there that needs to go into `environmentl.yml` here.